### PR TITLE
kcons - migrate to spring 2.2.6 + junit 5

### DIFF
--- a/kcons/build.gradle
+++ b/kcons/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'org.springframework.boot' version '2.1.13.RELEASE'
+	id 'org.springframework.boot' version '2.2.6.RELEASE'
 	id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 	id 'java'
 }
@@ -23,6 +23,28 @@ dependencies {
 	// https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
 	compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.10'
 
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation('org.springframework.boot:spring-boot-starter-test') {
+    exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+  }
+
+  // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.6.2'
+
+  // https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-migrationsupport
+  testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-migrationsupport', version: '5.6.2'
+
+  // https://mvnrepository.com/artifact/org.junit.platform/junit-platform-engine
+  testCompile group: 'org.junit.platform', name: 'junit-platform-engine', version: '1.6.2'
+
+  // https://mvnrepository.com/artifact/org.junit.platform/junit-platform-launcher
+  testCompile group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.6.2'
+
+  // https://mvnrepository.com/artifact/org.junit.platform/junit-platform-runner
+  testCompile group: 'org.junit.platform', name: 'junit-platform-runner', version: '1.6.2'
+	
 	testImplementation 'org.springframework.kafka:spring-kafka-test'
+}
+
+test {
+  useJUnitPlatform()
 }

--- a/kcons/src/test/java/com/github/coobik/kcons/KconsApplicationTests.java
+++ b/kcons/src/test/java/com/github/coobik/kcons/KconsApplicationTests.java
@@ -1,12 +1,12 @@
 package com.github.coobik.kcons;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 
-@RunWith(SpringRunner.class)
+@RunWith(JUnitPlatform.class)
 @SpringBootTest(
     properties = {
         "kafka.consumer.enabled=false"

--- a/kcons/src/test/java/com/github/coobik/kcons/kafka/MessageListenerTest.java
+++ b/kcons/src/test/java/com/github/coobik/kcons/kafka/MessageListenerTest.java
@@ -5,8 +5,9 @@ import java.util.concurrent.CountDownLatch;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -21,13 +22,12 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import com.github.coobik.kcons.model.Message;
 import com.github.coobik.kcons.service.MessageProcessor;
 
 
-@RunWith(SpringRunner.class)
+@RunWith(JUnitPlatform.class)
 @SpringBootTest(
     properties = {
         // set bootstrapServers to embedded kafka before listeners start
@@ -62,7 +62,7 @@ public class MessageListenerTest {
   @Value("${kafka.consumer.topic}")
   private String topic;
 
-  @Before
+  @BeforeEach
   public void beforeEach() {
     MockitoAnnotations.initMocks(this);
 


### PR DESCRIPTION
kcons - migrate to spring 2.2.6 + junit 5;
use JUnitPlatform runner;
use junit jupiter api;
